### PR TITLE
Add Parcel@2 cache folder to ignore list.

### DIFF
--- a/templates/Node.gitignore
+++ b/templates/Node.gitignore
@@ -74,6 +74,7 @@ typings/
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
+.parcel-cache
 
 # Next.js build output
 .next


### PR DESCRIPTION
# Pull Request

Thank you for contributing to @dvcs/gitignore and https://www.gitignore.io.

## New or update

Select the appropriate check box for this pull request. This helps when merging to ensure there are no conflicts with other templates or misunderstandings of how thee template list works.

### New

- [ ] Template - New `.gitignore` template
- [ ] Composition - Template made from smaller templates
- [ ] Inheritance - Template similar to an existing template
- [ ] Patch - Template extending functionality of existing template

### Update

- [x] Template - Update existing `.gitignore` template

## Details

Parcel v2 uses a different folder (`.parcel-cache`) to store a cache of processed modules/code to speed up next builds.

See: https://github.com/parcel-bundler/parcel#caching